### PR TITLE
w4_2.1: correct the return value for fixedpoint

### DIFF
--- a/week4/w4_2.1_first_class_functions.ml
+++ b/week4/w4_2.1_first_class_functions.ml
@@ -8,5 +8,5 @@ let rec fixedpoint f start delta =
   let current = f start in
   let next = f current in
   if abs_float (current -. next) < delta
-  then start
+  then current
   else fixedpoint f current delta


### PR DESCRIPTION
the start argument isn't involved in the comparison